### PR TITLE
Bug fix: wrong estimator updating in Metropolis algorithm

### DIFF
--- a/isingmodel/algorithms.py
+++ b/isingmodel/algorithms.py
@@ -79,5 +79,5 @@ def metropolis_update_state(
     :param energy_difference: Energy difference for the trial spin flip.
     """
     data.state[site_index] *= -1
-    data.estimators.energy_1st_moment += energy_difference
-    data.estimators.magnetization_1st_moment += 2 * data.state[site_index]
+    data.estimators.energy += energy_difference
+    data.estimators.magnetization += 2 * data.state[site_index]

--- a/isingmodel/distributions.py
+++ b/isingmodel/distributions.py
@@ -36,7 +36,7 @@ class BinaryLattice(object):
         :param site_index: Indices for site whose neighbor states you want to query.
         :param state: Array of lattice spins.
         :param neighborhood: Controls the number of neighbors returned, defaults to
-            "Neumann"
+            'Neumann'
         :return: Array of neighbor states.
         """
         neighbor_indices: np.array = self._get_neighbor_indices(


### PR DESCRIPTION
## Main fix

*   Now updates current energy and magnetization, not the running averages

## Other fixes

*   Documentation
    *   Fixed: only use single quotes inside a docstring