### PR TITLE
Implement computation of antiferromagnetic order parameter

### DIFF
--- a/isingmodel/algorithms.py
+++ b/isingmodel/algorithms.py
@@ -25,6 +25,7 @@ def metropolis(lattice: BinaryLattice, data: SimulationData) -> None:
     )
     if accept_state:
         metropolis_update_state(
+            lattice=lattice,
             data=data,
             site_index=site_index,
             energy_difference=energy_difference,
@@ -62,19 +63,28 @@ def metropolis_accept_or_reject(temperature: float, energy_difference: float) ->
 
 
 def metropolis_update_state(
+    lattice: BinaryLattice,
     data: SimulationData,
     site_index: int,
     energy_difference: float,
 ) -> None:
     """Accept trial flip and update simulation state.
 
+    :param lattice: Structural information and neighbor tables.
     :param data: Data container for the simulation.
     :param site_index: Index for randomly chosen site.
     :param energy_difference: Energy difference for the trial spin flip.
     """
     data.state[site_index] *= -1
     data.estimators.energy += energy_difference
-    data.estimators.magnetization += 2 * data.state[site_index]
+    magnetization_change = 2 * data.state[site_index]
+    data.estimators.magnetization += magnetization_change
+
+    if site_index in lattice.even_site_indices:
+        data.estimators.magnetization_even_sites += magnetization_change
+
+    else:
+        data.estimators.magnetization_odd_sites += magnetization_change
 
 
 def metropolis_proposal_distribution(

--- a/isingmodel/data.py
+++ b/isingmodel/data.py
@@ -43,6 +43,16 @@ class Estimators(object):
     magnetization_2nd_moment: float
     magnetization_3rd_moment: float
     magnetization_4th_moment: float
+    magnetization_even_sites: float
+    magnetization_even_sites_1st_moment: float
+    magnetization_even_sites_2nd_moment: float
+    magnetization_even_sites_3rd_moment: float
+    magnetization_even_sites_4th_moment: float
+    magnetization_odd_sites: float
+    magnetization_odd_sites_1st_moment: float
+    magnetization_odd_sites_2nd_moment: float
+    magnetization_odd_sites_3rd_moment: float
+    magnetization_odd_sites_4th_moment: float
     __slots__ = [
         "energy",
         "energy_1st_moment",
@@ -54,6 +64,16 @@ class Estimators(object):
         "magnetization_2nd_moment",
         "magnetization_3rd_moment",
         "magnetization_4th_moment",
+        "magnetization_even_sites",
+        "magnetization_even_sites_1st_moment",
+        "magnetization_even_sites_2nd_moment",
+        "magnetization_even_sites_3rd_moment",
+        "magnetization_even_sites_4th_moment",
+        "magnetization_odd_sites",
+        "magnetization_odd_sites_1st_moment",
+        "magnetization_odd_sites_2nd_moment",
+        "magnetization_odd_sites_3rd_moment",
+        "magnetization_odd_sites_4th_moment",
     ]
 
 
@@ -68,6 +88,14 @@ class SimulationTrace(object):
     magnetization_2nd_moment: List[Union[float, None]]
     magnetization_3rd_moment: List[Union[float, None]]
     magnetization_4th_moment: List[Union[float, None]]
+    magnetization_even_sites_1st_moment: List[Union[float, None]]
+    magnetization_even_sites_2nd_moment: List[Union[float, None]]
+    magnetization_even_sites_3rd_moment: List[Union[float, None]]
+    magnetization_even_sites_4th_moment: List[Union[float, None]]
+    magnetization_odd_sites_1st_moment: List[Union[float, None]]
+    magnetization_odd_sites_2nd_moment: List[Union[float, None]]
+    magnetization_odd_sites_3rd_moment: List[Union[float, None]]
+    magnetization_odd_sites_4th_moment: List[Union[float, None]]
     __slots__ = [
         "sweep",
         "energy_1st_moment",
@@ -78,6 +106,14 @@ class SimulationTrace(object):
         "magnetization_2nd_moment",
         "magnetization_3rd_moment",
         "magnetization_4th_moment",
+        "magnetization_even_sites_1st_moment",
+        "magnetization_even_sites_2nd_moment",
+        "magnetization_even_sites_3rd_moment",
+        "magnetization_even_sites_4th_moment",
+        "magnetization_odd_sites_1st_moment",
+        "magnetization_odd_sites_2nd_moment",
+        "magnetization_odd_sites_3rd_moment",
+        "magnetization_odd_sites_4th_moment",
     ]
 
 
@@ -107,8 +143,11 @@ def setup_containers(
     return SimulationData(
         parameters=parameters,
         state=state,
-        trace=SimulationTrace([], [], [], [], [], [], [], [], []),
-        estimators=Estimators(0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        trace=SimulationTrace([], [], [], [], [], [], [], [], [], [], [], [], [], [],
+                              [], [], []),
+        estimators=Estimators(
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ),
     )
 
 
@@ -144,6 +183,30 @@ def update_trace(data: SimulationData, sweep_index: int, number_sites: int) -> N
     data.trace.magnetization_4th_moment.append(
         data.estimators.magnetization_4th_moment / number_sites
     )
+    data.trace.magnetization_even_sites_1st_moment.append(
+        data.estimators.magnetization_even_sites_1st_moment / number_sites
+    )
+    data.trace.magnetization_even_sites_2nd_moment.append(
+        data.estimators.magnetization_even_sites_2nd_moment / number_sites
+    )
+    data.trace.magnetization_even_sites_3rd_moment.append(
+        data.estimators.magnetization_even_sites_3rd_moment / number_sites
+    )
+    data.trace.magnetization_even_sites_4th_moment.append(
+        data.estimators.magnetization_even_sites_4th_moment / number_sites
+    )
+    data.trace.magnetization_odd_sites_1st_moment.append(
+        data.estimators.magnetization_odd_sites_1st_moment / number_sites
+    )
+    data.trace.magnetization_odd_sites_2nd_moment.append(
+        data.estimators.magnetization_odd_sites_2nd_moment / number_sites
+    )
+    data.trace.magnetization_odd_sites_3rd_moment.append(
+        data.estimators.magnetization_odd_sites_3rd_moment / number_sites
+    )
+    data.trace.magnetization_odd_sites_4th_moment.append(
+        data.estimators.magnetization_odd_sites_4th_moment / number_sites
+    )
 
 
 def write_trace_to_disk(data: SimulationData) -> None:
@@ -151,17 +214,26 @@ def write_trace_to_disk(data: SimulationData) -> None:
 
     :param data: Data container for the simulation.
     """
-    trace_df: pd.DataFrame = pd.DataFrame({
-        "sweep": data.trace.sweep,
-        "E^1": data.trace.energy_1st_moment,
-        "E^2": data.trace.energy_2nd_moment,
-        "E^3": data.trace.energy_3rd_moment,
-        "E^4": data.trace.energy_4th_moment,
-        "M^1": data.trace.magnetization_1st_moment,
-        "M^2": data.trace.magnetization_2nd_moment,
-        "M^3": data.trace.magnetization_3rd_moment,
-        "M^4": data.trace.magnetization_4th_moment,
-    })
+    trace_df: pd.DataFrame = \
+        pd.DataFrame({
+            "sweep": data.trace.sweep,
+            "E": data.trace.energy_1st_moment,
+            "E**2": data.trace.energy_2nd_moment,
+            "E**3": data.trace.energy_3rd_moment,
+            "E**4": data.trace.energy_4th_moment,
+            "M": data.trace.magnetization_1st_moment,
+            "M**2": data.trace.magnetization_2nd_moment,
+            "M**3": data.trace.magnetization_3rd_moment,
+            "M**4": data.trace.magnetization_4th_moment,
+            "M_even": data.trace.magnetization_even_sites_1st_moment,
+            "M_even**2": data.trace.magnetization_even_sites_2nd_moment,
+            "M_even**3": data.trace.magnetization_even_sites_3rd_moment,
+            "M_even**4": data.trace.magnetization_even_sites_4th_moment,
+            "M_odd": data.trace.magnetization_odd_sites_1st_moment,
+            "M_odd**2": data.trace.magnetization_odd_sites_2nd_moment,
+            "M_odd**3": data.trace.magnetization_odd_sites_3rd_moment,
+            "M_odd**4": data.trace.magnetization_odd_sites_4th_moment,
+        })
 
     if data.parameters.trace_filepath:
         trace_df.to_csv(path_or_buf=data.parameters.trace_filepath, index=False)

--- a/isingmodel/lattice.py
+++ b/isingmodel/lattice.py
@@ -19,11 +19,13 @@ class BinaryLattice(object):
         "_neighbor_count_list",
         "_neighbor_table_lookup_index",
         "_interaction_parameters_table",
+        "_even_site_indices",
+        "_odd_site_indices",
         "_number_sites",
     ]
 
     def __init__(self, dimensions, neighborhood, interaction_parameters):
-        """Initialize BinaryLattice object and build neighbor tables.
+        """Initialize attributes, build neighbor tables, and cache even/odd indices.
         
         :param dimensions: Number of sites along x and y dimensions of square lattice.
         :param neighborhood: Controls the number of neighbors returned.
@@ -34,11 +36,22 @@ class BinaryLattice(object):
         self._number_sites: int = int(np.prod(dimensions))
         self._build_and_cache_neighbor_table()
         self._build_and_cache_interaction_parameter_table(interaction_parameters)
+        self._cache_even_and_odd_site_indices()
 
     @property
     def number_sites(self):
         """Total sites in the simulation."""
         return self._number_sites
+
+    @property
+    def even_site_indices(self):
+        """Even site indices on the lattice."""
+        return self._even_site_indices
+
+    @property
+    def odd_site_indices(self):
+        """Odd site indices on the lattice."""
+        return self._odd_site_indices
 
     def sample_random_state(self) -> np.ndarray:
         """Generate sample of random states on the binary lattice."""
@@ -243,3 +256,25 @@ class BinaryLattice(object):
         indices[indices[:, 0] >= self.dimensions[0], 0] = 0
         indices[indices[:, 1] < 0, 1] = self.dimensions[1] - 1
         indices[indices[:, 1] >= self.dimensions[1], 1] = 0
+
+    def _cache_even_and_odd_site_indices(self):
+        """Find and cache indices for even and odd lattice sites."""
+        self._even_site_indices: List[int] = [
+            row * self.dimensions[1] + column
+            for row in range(0, self.dimensions[0], 2)
+            for column in range(0, self.dimensions[1], 2)
+        ] + [
+            row * self.dimensions[1] + column
+            for row in range(1, self.dimensions[0], 2)
+            for column in range(1, self.dimensions[1], 2)
+        ]
+
+        self._odd_site_indices: List[int] = [
+            row * self.dimensions[1] + column
+            for row in range(0, self.dimensions[0], 2)
+            for column in range(1, self.dimensions[1], 2)
+        ] + [
+            row * self.dimensions[1] + column
+            for row in range(1, self.dimensions[0], 2)
+            for column in range(0, self.dimensions[1], 2)
+        ]

--- a/isingmodel/model.py
+++ b/isingmodel/model.py
@@ -40,6 +40,14 @@ def ising_save_full_state(lattice: BinaryLattice, data: SimulationData) -> None:
         data=data,
     )
     data.estimators.magnetization = ising_total_magnetization(data=data)
+    data.estimators.magnetization_even_sites = ising_total_magnetization_even_sites(
+        lattice=lattice,
+        data=data,
+    )
+    data.estimators.magnetization_odd_sites = ising_total_magnetization_odd_sites(
+        lattice=lattice,
+        data=data,
+    )
 
 
 def ising_total_energy(lattice: BinaryLattice, data: SimulationData) -> float:
@@ -68,6 +76,32 @@ def ising_total_magnetization(data: SimulationData) -> float:
     :return: Total magnetization of the simulation state.
     """
     return data.state.sum()
+
+
+def ising_total_magnetization_even_sites(
+    lattice: BinaryLattice,
+    data: SimulationData,
+) -> float:
+    """Compute the total magnetization estimator for the even sites on the lattice.
+
+    :param lattice: Structural information and neighbor tables.
+    :param data: Data container for the simulation.
+    :return: Total magnetization of the simulation state.
+    """
+    return data.state[lattice.even_site_indices].sum()
+
+
+def ising_total_magnetization_odd_sites(
+    lattice: BinaryLattice,
+    data: SimulationData,
+) -> float:
+    """Compute the total magnetization estimator for the even sites on the lattice.
+
+    :param lattice: Structural information and neighbor tables.
+    :param data: Data container for the simulation.
+    :return: Total magnetization of the simulation state.
+    """
+    return data.state[lattice.odd_site_indices].sum()
 
 
 def ising_compute_site_energy(

--- a/isingmodel/run.py
+++ b/isingmodel/run.py
@@ -82,15 +82,21 @@ def post_simulation(
     lattice: BinaryLattice,
     data: SimulationData,
 ) -> None:
-    """Write the simulation history to disk and print energy and magnetization
-    estimators.
+    """Write the simulation history to disk and print estimators.
 
     :param lattice: Structural information and neighbor tables.
     :param data: Data container for the simulation.
     """
     isingmodel.data.write_trace_to_disk(data=data)
-    print(f"Energy = {data.estimators.energy_1st_moment / lattice.number_sites}")
-    print(
-        "Magnetization = "
-        f"{data.estimators.magnetization_1st_moment / lattice.number_sites}"
-    )
+
+    average_energy: float = \
+        data.estimators.energy_1st_moment / lattice.number_sites
+    fm_order_parameter: float = \
+        data.estimators.magnetization_1st_moment / lattice.number_sites
+    afm_order_parameter: float = (
+        data.estimators.magnetization_even_sites_1st_moment -
+        data.estimators.magnetization_odd_sites_1st_moment
+    ) / lattice.number_sites
+    print(f"Average energy = {average_energy}")
+    print(f"FM order parameter = {fm_order_parameter}")
+    print(f"AFM order parameter = {afm_order_parameter}")

--- a/isingmodel/statistics.py
+++ b/isingmodel/statistics.py
@@ -36,11 +36,18 @@ def update_estimators(data: SimulationData, number_samples: int) -> None:
     :param number_samples: Number of samples currently in mean.
     """
     estimator_means_list: List[str] = ([
-        f"{parameter}_{moment}_moment" for parameter in ["energy", "magnetization"]
-        for moment in ["1st", "2nd", "3rd", "4th"]
+        f"{parameter}_{moment}_moment" for parameter in [
+            "energy",
+            "magnetization",
+            "magnetization_even_sites",
+            "magnetization_odd_sites",
+        ] for moment in ["1st", "2nd", "3rd", "4th"]
     ])
-    estimator_samples_list: List[str] = 4 * ["energy"] + 4 * ["magnetization"]
-    powers_list: List[int] = 2 * list(range(1, 5))
+    estimator_samples_list: List[str] = (
+        4 * ["energy"] + 4 * ["magnetization"] + 4 * ["magnetization_even_sites"] +
+        4 * ["magnetization_odd_sites"]
+    )
+    powers_list: List[int] = 4 * list(range(1, 5))
     estimators_zip: Iterable = \
         zip(estimator_means_list, estimator_samples_list, powers_list)
 


### PR DESCRIPTION
* Find and cache even/odd site indices using BinaryLattice class
* Store state and trace of magnetization on even and odd lattice sites
* Methods to compute the total magnetization of the even and odd sites
* Update even/odd magnetization state after successful test flip
* Update trace with running averages of the magnetization of even and odd sites
* Output FM and AFM order parameters at end of simulation run